### PR TITLE
String fixes

### DIFF
--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -11,7 +11,7 @@
             <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Show shortcuts</property>
+                <property name="title" translatable="yes" context="shortcut window">Keyboard Shortcuts</property>
                 <property name="action-name">win.show-help-overlay</property>
               </object>
             </child>
@@ -23,43 +23,43 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Scroll left</property>
+                <property name="title" translatable="yes" context="shortcut window">Scroll Back</property>
                 <property name="accelerator">Left</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Scroll right</property>
+                <property name="title" translatable="yes" context="shortcut window">Scroll Forward</property>
                 <property name="accelerator">Right</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Toggle lock mode</property>
+                <property name="title" translatable="yes" context="shortcut window">Lock Mode</property>
                 <property name="accelerator">&lt;ctrl&gt;d</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Preview selected item</property>
+                <property name="title" translatable="yes" context="shortcut window">Preview Selected Item</property>
                 <property name="accelerator">&lt;ctrl&gt;o</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Delete selected item</property>
+                <property name="title" translatable="yes" context="shortcut window">Delete Selected Item</property>
                 <property name="accelerator">BackSpace</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Remove all items</property>
+                <property name="title" translatable="yes" context="shortcut window">Remove All Items</property>
                 <property name="accelerator">Delete</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Paste from clipboard</property>
+                <property name="title" translatable="yes" context="shortcut window">Paste Item</property>
                 <property name="accelerator">&lt;ctrl&gt;v</property>
               </object>
             </child>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -13,8 +13,8 @@
             <property name="title" translatable="yes">General</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Always keep items when dragging out</property>
-                <property name="subtitle" translatable="yes">This option also disables the Alt shortcut.</property>
+                <property name="title" translatable="yes">Keep Items</property>
+                <property name="subtitle" translatable="yes">Keep items even when they're dragged out. This option also disables the Alt shortcut.</property>
                 <child>
                   <object class="GtkSwitch" id="keep_items_when_dragging">
                     <property name="valign">center</property>
@@ -24,8 +24,8 @@
             </child>
             <child>
               <object class="AdwActionRow" id="download_images_row">
-                <property name="title" translatable="yes">Download images from URLs</property>
-                <property name="subtitle" translatable="yes">If the dropped text is an URL that links to an image, the image is automatically downloaded and saved.</property>
+                <property name="title" translatable="yes">Download Images From URLs</property>
+                <property name="subtitle" translatable="yes">If the dropped text is a URL that links to an image, the image is automatically downloaded and saved</property>
                 <child>
                   <object class="GtkSwitch" id="download_images">
                     <property name="valign">center</property>
@@ -35,8 +35,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Collect text strings as a CSV file</property>
-                <property name="subtitle" translatable="yes">When enabled, plain text strings are collected in a single CSV file. URLs that link to images will still follow the respective setting.</property>
+                <property name="title" translatable="yes">Collect Strings as CSV File</property>
+                <property name="subtitle" translatable="yes">Collect plain text strings in a single CSV file. URLs that link to images will still follow the respective setting.</property>
                 <child>
                   <object class="GtkSwitch" id="text_as_csv">
                     <property name="valign">center</property>
@@ -48,11 +48,11 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="title" translatable="yes">Window behaviour</property>
+            <property name="title" translatable="yes">Window Behavior</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Get GNOME extension</property>
-                <property name="subtitle" translatable="yes">The extention adds cool features like forcing Collector to stay always on top of other windows!</property>
+                <property name="title" translatable="yes">GNOME Extension</property>
+                <property name="subtitle" translatable="yes">The extension adds features like forcing Collector to always stay on top of other windows</property>
                 <child>
                   <object class="GtkButton" id="open_gnome_ext">
                     <property name="icon-name">arrow2-top-right-symbolic</property>
@@ -63,7 +63,7 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Learn how to configure Collector on KDE</property>
+                <property name="title" translatable="yes">Configure Collector on KDE</property>
                 <child>
                   <object class="GtkButton" id="configure_kde">
                     <property name="icon-name">arrow2-top-right-symbolic</property>
@@ -74,8 +74,8 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Open Collector with a shortcut</property>
-                <property name="subtitle" translatable="yes">Use this code to create a custom shortcut for Collector in the system settings.</property>
+                <property name="title" translatable="yes">Open Collector With a Shortcut</property>
+                <property name="subtitle" translatable="yes">Use this command to create a custom shortcut for Collector in the system settings</property>
                 <child>
                   <object class="GtkLabel" id="launch_shortcut">
                     <property name="selectable">yes</property>
@@ -90,11 +90,11 @@
                 <property name="model">
                   <object class="GtkStringList">
                     <items>
-                      <item>1 -</item>
-                      <item>2 -</item>
-                      <item>3 -</item>
-                      <item>4 -</item>
-                      <item>5 -</item>
+                      <item>1</item>
+                      <item>2</item>
+                      <item>3</item>
+                      <item>4</item>
+                      <item>5</item>
                     </items>
                   </object>
                 </property>
@@ -109,8 +109,8 @@
             <property name="title" translatable="yes">Integrations</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Google Images URL support</property>
-                <property name="subtitle" translatable="yes">Automatically analyse and download files from Google Images links.</property>
+                <property name="title" translatable="yes">Google Images URL Support</property>
+                <property name="subtitle" translatable="yes">Automatically analyze and download files from Google Images links</property>
                 <child>
                   <object class="GtkSwitch" id="google_images_support">
                     <property name="valign">center</property>
@@ -126,8 +126,8 @@
             <property name="title" translatable="yes">Debugging</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Enable debug logs</property>
-                <property name="subtitle" translatable="yes">Increase log verbosity.</property>
+                <property name="title" translatable="yes">Enable Debug Logs</property>
+                <property name="subtitle" translatable="yes">Increase the log verbosity</property>
                 <child>
                   <object class="GtkSwitch" id="debug_logs">
                     <property name="valign">center</property>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -42,11 +42,6 @@ class SettingsWindow(Adw.PreferencesWindow):
         self.settings.bind('debug-logs', self.debug_logs, 
         'active', Gio.SettingsBindFlags.DEFAULT)
 
-        download_images_sbt = self.download_images_row.get_subtitle()
-        suported_formats_str = '\n\n' + _('The following image formats are currently supported: ')
-        suported_formats_str += ', '.join([s.split('/')[1] for s in SUPPORTED_IMG_TYPES])
-        self.download_images_row.set_subtitle(download_images_sbt + suported_formats_str)
-
         self.launch_shortcut_windows.connect('notify::selected', self.on_launch_shortcuts_wd_changed)
 
         self.launch_shortcut.set_label(f'flatpak run {APP_ID}')

--- a/src/window.py
+++ b/src/window.py
@@ -274,7 +274,7 @@ class CollectorWindow(Adw.ApplicationWindow):
     def on_drop_enter(self, widget, x, y):
         if not self.is_dragging_away:
             self.icon_stack.set_visible_child(self.release_drop_icon)
-            self.drops_label.set_label(_('Release to collect'))
+            self.drops_label.set_label(_('Release to Collect'))
 
         return Gdk.DragAction.COPY
 

--- a/src/window.py
+++ b/src/window.py
@@ -36,7 +36,7 @@ class CollectorWindow(Adw.ApplicationWindow):
 
     
     COLLECTOR_COLORS = ["blue", "yellow", "purple", "rose", "orange", "green"]
-    EMPTY_DROP_TEXT = _('Drop content here')
+    EMPTY_DROP_TEXT = _('Drop Content Here')
     CAROUSEL_ICONS_PIX_SIZE=50
     DROPS_BASE_PATH = GLib.get_user_cache_dir() + f'/drops'
     settings = get_gsettings()


### PR DESCRIPTION
Move titles to title case, remove periods in subtitles, remove image support text (should be in the app description). There are other changes outside of the scope of this MR that I would like to propose:

- Remove the Debugging stuff from the interface, normal users shouldn't have to worry about this. (This includes the "Open Log File" button in the Main Menu, which should be moved to the About window, and the section in the Preferences)

- Turn the rows that link to external sites into activatable rows, and use "adw-external-link-symbolic" as the icon. A UI reference for this can be found at https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/main/panels/system/cc-system-panel.ui?ref_type=heads#L95-107