### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/it.mijorus.collector.metainfo.xml.in
+++ b/data/it.mijorus.collector.metainfo.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
 	<id>it.mijorus.collector.desktop</id>
-	<name translatable="no">Collector</name>
+	<name translate="no">Collector</name>
     <summary>Drag and Drop to the next level</summary>
     <url type="donation">https://ko-fi.com/mijorus</url>
     <url type="homepage">https://mijorus.it/projects/collector</url>
@@ -11,9 +11,9 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0-or-later</project_license>
     <!-- developer_name tag deprecated with Appstream 1.0 -->
-    <developer_name translatable="no">Lorenzo Paderi</developer_name>
+    <developer_name translate="no">Lorenzo Paderi</developer_name>
     <developer id="mijorus.it">
-        <name translatable="no">Lorenzo Paderi</name>
+        <name translate="no">Lorenzo Paderi</name>
     </developer>
     <description>
         <p>Collector is a simple utility that allows you to drag multiple files into a single window and drop them anywhere! It can also download images automatically when pasting urls.</p>
@@ -22,13 +22,13 @@
     <launchable type="desktop-id">it.mijorus.collector.desktop</launchable>
 	<releases>
 		<release type="stable" version="1.0.1" date="2024-02-05T00:00:00Z">
-            <description translatable="no">
+            <description translate="no">
                 <p>- Added translations</p>
                 <p>- Bug fix</p>
             </description>
         </release>
 		<release type="stable" version="1.0.0" date="2024-01-12T00:00:00Z">
-            <description translatable="no">
+            <description translate="no">
                 <p>- First release</p>
             </description>
         </release>

--- a/data/it.mijorus.collector.metainfo.xml.in
+++ b/data/it.mijorus.collector.metainfo.xml.in
@@ -4,9 +4,9 @@
 	<name translate="no">Collector</name>
     <summary>Drag and Drop to the next level</summary>
     <url type="donation">https://ko-fi.com/mijorus</url>
-    <url type="homepage">https://mijorus.it/projects/collector</url>
+    <url type="homepage">https://mijorus.it/projects/collector/</url>
     <url type="bugtracker">https://github.com/mijorus/collector/issues</url>
-    <url type="vcs-browser">https://mijorus.it/projects/collector</url>
+    <url type="vcs-browser">https://github.com/mijorus/collector</url>
     <url type="translate">https://github.com/mijorus/collector/tree/master/po</url>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0-or-later</project_license>

--- a/data/it.mijorus.collector.metainfo.xml.in
+++ b/data/it.mijorus.collector.metainfo.xml.in
@@ -12,7 +12,7 @@
     <project_license>GPL-3.0-or-later</project_license>
     <!-- developer_name tag deprecated with Appstream 1.0 -->
     <developer_name translate="no">Lorenzo Paderi</developer_name>
-    <developer id="mijorus.it">
+    <developer id="it.mijorus">
         <name translate="no">Lorenzo Paderi</name>
     </developer>
     <description>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Update two URLs

- Fix unreachable homepage URL
- Fix vcs-browser URL which should point the source core repository